### PR TITLE
Added Bootswatch theme, cleaned up the HTML  a bit

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -6,30 +6,37 @@
 		<meta charset="utf-8">
 		<title>PaleorXiv</title>
 
-		<!-- Latest compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+		<!-- Latest compiled and minified CSS -- YETI from bootswatch theme -->
+		<link href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0-beta.3/yeti/bootstrap.min.css" rel="stylesheet" integrity="sha384-xpQNcoacYF/4TKVs2uD3sXyaQYs49wxwEmeFNkOUgun6SLWdEbaCOv8hGaB9jLxt" crossorigin="anonymous">
+		
+		<!-- Latest compiled and minified FontAwesome -->
+		<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
 		<!-- Latest compiled and minified JavaScript -->
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.bundle.min.js" integrity="sha384-VspmFJ2uqRrKr3en+IG0cIq1Cl/v/PHneDw6SQZYgrcr8ZZmZoQ3zhuGfMnSR/F2" crossorigin="anonymous"></script>
 		
-		<style>
-		
-			.main_logo { 
+	<style>	
+ 		.main_logo { 
 				display: block; 
 				margin-right: auto; 
 				margin-left: auto; 
 				width: 550px; 
 				height: 297px; 
 			}
+			
+			.nav-item {
+			 padding:3px;
+			}
+			
+			.nav-link {
+			 font-size:1.4em;
+			}
+			
 			.navbar-nav {
     			float:none;
    				margin: auto;
-    			/* vertical menu */
-    			/* display: block; */
     			text-align: center;
 			}
-			.navbar .active { background: #cacdd1; }
-                        .text { padding-top: 25px; }
 		</style>
 	</head>
 
@@ -40,16 +47,18 @@
 
 			<nav class="navbar navbar-toggleable-md navbar-light bg-faded">
 
-  				<div class="collapse navbar-collapse" id="navbarSupportedContent">
-    				<ul class="navbar-nav mr-auto">
-      					<li class="nav-item active">
+  				<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
+		  <span class="navbar-toggler-icon"></span>
+		</button>
+
+		<div class="collapse navbar-collapse" id="navbarColor01">
+		  <ul class="navbar-nav mr-auto">
+		  <li class="nav-item">
         					<a class="nav-link" href="index.html">Home 
         					<span class="sr-only">(current)</span></a>
       					</li>
-      					<li class="nav-item">
-        					<a class="nav-link" href="faq.html">FAQ</a>
-      					</li>
-					<li class="nav-item">
+      <li class="nav-item">
         					<a class="nav-link" href="submission_guidelines.html">Submission Guidelines</a>
       					</li>
 					<li class="nav-item">
@@ -59,23 +68,30 @@
         					<a class="nav-link" href="moderation.html">Moderation</a>
       					</li>
       					<li class="nav-item">
-        					<a class="nav-link" href="resources.html">Resources</a>
-      					</li>
-      					<li class="nav-item">
-        					<a class="nav-link" href="blog.html">Blog</a>
-      					</li>
-      					<li class="nav-item">
         					<a class="nav-link" href="diversity_statement.html">Diversity Statement</a>
       					</li>
 					<li class="nav-item">
         					<a class="nav-link" href="code_of_conduct.html">Code of Conduct</a>
       					</li>
-  				</div>
-			
-			</nav>
+					<li class="nav-item">
+        					<a class="nav-link" href="resources.html">Resources</a>
+					</li>
+					<li class="nav-item">
+        					<a class="nav-link" href="faq.html">FAQ</a>
+      					</li>
+     </ul>
+		</div>
+	</nav>
                        
-			Coming soon!					
+				<h2 style="padding-top:1em;">COMING SOON</h2>				
 
+			<footer id="footer">
+			<hr/>	
+			
+			<!-- add a license here -->
+			           
+      <p>Contact email: <a href="mailto:jon.tennant.2@gmail.com">jon dot tennant dot 2 at gmail dot com</a>. Source code can found at <a href="https://github.com/paleorXiv/paleorXiv.github.io">paleorXiv/paleorXiv.github.io</a>. Based on <a href="https://getbootstrap.com" rel="nofollow">Bootstrap</a>. Theme is <a href="https://bootswatch.com/yeti/">Yeti</a> from <a href="https://bootswatch.com/">Bootswatch</a>. Icons from <a href="http://fontawesome.io/" rel="nofollow">Font Awesome</a>.</p>
+    </footer>	
 		</div>
 	</body>
 </html>

--- a/code_of_conduct.html
+++ b/code_of_conduct.html
@@ -6,30 +6,37 @@
 		<meta charset="utf-8">
 		<title>PaleorXiv</title>
 
-		<!-- Latest compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+		<!-- Latest compiled and minified CSS -- YETI from bootswatch theme -->
+		<link href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0-beta.3/yeti/bootstrap.min.css" rel="stylesheet" integrity="sha384-xpQNcoacYF/4TKVs2uD3sXyaQYs49wxwEmeFNkOUgun6SLWdEbaCOv8hGaB9jLxt" crossorigin="anonymous">
+		
+		<!-- Latest compiled and minified FontAwesome -->
+		<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
 		<!-- Latest compiled and minified JavaScript -->
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.bundle.min.js" integrity="sha384-VspmFJ2uqRrKr3en+IG0cIq1Cl/v/PHneDw6SQZYgrcr8ZZmZoQ3zhuGfMnSR/F2" crossorigin="anonymous"></script>
 		
-		<style>
-		
-			.main_logo { 
+	<style>	
+ 		.main_logo { 
 				display: block; 
 				margin-right: auto; 
 				margin-left: auto; 
 				width: 550px; 
 				height: 297px; 
 			}
+			
+			.nav-item {
+			 padding:3px;
+			}
+			
+			.nav-link {
+			 font-size:1.4em;
+			}
+			
 			.navbar-nav {
     			float:none;
    				margin: auto;
-    			/* vertical menu */
-    			/* display: block; */
     			text-align: center;
 			}
-			.navbar .active { background: #cacdd1; }
-                        .text { padding-top: 25px; }
 		</style>
 	</head>
 
@@ -38,15 +45,18 @@
 		
 		<div class="container">
 
-			<nav class="navbar navbar-toggleable-md navbar-light bg-faded">
+			<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
+		  <span class="navbar-toggler-icon"></span>
+		</button>
 
-  				<div class="collapse navbar-collapse" id="navbarSupportedContent">
-    				<ul class="navbar-nav mr-auto">
-      					<li class="nav-item">
+		<div class="collapse navbar-collapse" id="navbarColor01">
+		  <ul class="navbar-nav mr-auto">
+		  <li class="nav-item">
         					<a class="nav-link" href="index.html">Home 
         					<span class="sr-only">(current)</span></a>
       					</li>
-      					<li class="nav-item">
+      <li class="nav-item">
         					<a class="nav-link" href="submission_guidelines.html">Submission Guidelines</a>
       					</li>
 					<li class="nav-item">
@@ -67,47 +77,54 @@
 					<li class="nav-item">
         					<a class="nav-link" href="faq.html">FAQ</a>
       					</li>
-  				</div>
-			
-			</nav>
+     </ul>
+		</div>
+	</nav>
 				
-		<br/><h4>paleorXiv Code of Conduct</h4>
+	<h3 style="padding-top:1em;">paleorXiv Code of Conduct</h3>
                        
-<p style="text-align: justify;">In the interest of fostering an open and welcoming environment, we as contributors and maintainers of paleorXiv pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.</p>
+	<p>In the interest of fostering an open and welcoming environment, we as contributors and maintainers of paleorXiv pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.</p>
 
-<h4 style="text-align: justify;">Our Standards</h4>
-<p style="text-align: justify;">Examples of behavior that contributes to creating a positive environment include:</p>
+	<h4>Our Standards</h4>
+		<p>Examples of behavior that contributes to creating a positive environment include:</p>
+		<ul>
+		 	<li>Using welcoming and inclusive language</li>
+		 	<li>Being respectful of differing viewpoints and experiences</li>
+		 	<li>Gracefully accepting constructive criticism</li>
+		 	<li>Focusing on what is best for the community</li>
+		 	<li>Showing empathy towards other community members</li>
+		</ul>
+	
+		<p>Examples of unacceptable behavior by participants include:</p>
+		<ul>
+		 	<li>The use of sexualized language or imagery and unwelcome sexual attention or advances</li>
+		 	<li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
+		 	<li>Public or private harassment</li>
+		 	<li>Publishing others’ private information, such as a physical or electronic address, without explicit permission</li>
+		 	<li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
+		</ul>
+				
+		<h4>Our Responsibilities</h4>
+			<p>Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.</p>
+			<p>Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.</p>
+				
+		<h4>Scope</h4>
+			<p>This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.</p>
+				
+		<h4>Enforcement</h4>
+			<p>Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team <a href="mailto:jon.tennant.2@gmail.com">here</a>. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The paleorXiv team is obligated to maintain confidentiality, to the extent permissible by law, with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.</p>
+			<p>Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.</p>
+				
+		<h4>Attribution</h4>
+			<p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org/">Contributor Covenant</a>, version 1.4, available at <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct.html">https://www.contributor-covenant.org/version/1/4/code-of-conduct.html</a></p>	
 
-<ul style="text-align: justify;">
- 	<li>Using welcoming and inclusive language</li>
- 	<li>Being respectful of differing viewpoints and experiences</li>
- 	<li>Gracefully accepting constructive criticism</li>
- 	<li>Focusing on what is best for the community</li>
- 	<li>Showing empathy towards other community members</li>
-</ul>
-<p style="text-align: justify;">Examples of unacceptable behavior by participants include:</p>
-
-<ul style="text-align: justify;">
- 	<li>The use of sexualized language or imagery and unwelcome sexual attention or advances</li>
- 	<li>Trolling, insulting/derogatory comments, and personal or political attacks</li>
- 	<li>Public or private harassment</li>
- 	<li>Publishing others’ private information, such as a physical or electronic address, without explicit permission</li>
- 	<li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
-</ul>
-				
-<h4 style="text-align: justify;">Our Responsibilities</h4>
-<p style="text-align: justify;">Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.</p>
-<p style="text-align: justify;">Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.</p>
-				
-<h4 style="text-align: justify;">Scope</h4>
-<p style="text-align: justify;">This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.</p>
-				
-<h4 style="text-align: justify;">Enforcement</h4>
-<p style="text-align: justify;">Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team <a href="mailto:jon.tennant.2@gmail.com">here</a>. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The paleorXiv team is obligated to maintain confidentiality, to the extent permissible by law, with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.</p>
-<p style="text-align: justify;">Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.</p>
-				
-<h4 style="text-align: justify;">Attribution</h4>
-<p style="text-align: justify;">This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org/">Contributor Covenant</a>, version 1.4, available at <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct.html">https://www.contributor-covenant.org/version/1/4/code-of-conduct.html</a></p>	
+	<footer id="footer">
+			<hr/>	
+			
+			<!-- add a license here -->
+			           
+      <p>Contact email: <a href="mailto:jon.tennant.2@gmail.com">jon dot tennant dot 2 at gmail dot com</a>. Source code can found at <a href="https://github.com/paleorXiv/paleorXiv.github.io">paleorXiv/paleorXiv.github.io</a>. Based on <a href="https://getbootstrap.com" rel="nofollow">Bootstrap</a>. Theme is <a href="https://bootswatch.com/yeti/">Yeti</a> from <a href="https://bootswatch.com/">Bootswatch</a>. Icons from <a href="http://fontawesome.io/" rel="nofollow">Font Awesome</a>.</p>
+    </footer>	
 
 		</div>
 	</body>

--- a/diversity_statement.html
+++ b/diversity_statement.html
@@ -6,30 +6,37 @@
 		<meta charset="utf-8">
 		<title>PaleorXiv</title>
 
-		<!-- Latest compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+		<!-- Latest compiled and minified CSS -- YETI from bootswatch theme -->
+		<link href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0-beta.3/yeti/bootstrap.min.css" rel="stylesheet" integrity="sha384-xpQNcoacYF/4TKVs2uD3sXyaQYs49wxwEmeFNkOUgun6SLWdEbaCOv8hGaB9jLxt" crossorigin="anonymous">
+		
+		<!-- Latest compiled and minified FontAwesome -->
+		<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
 		<!-- Latest compiled and minified JavaScript -->
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.bundle.min.js" integrity="sha384-VspmFJ2uqRrKr3en+IG0cIq1Cl/v/PHneDw6SQZYgrcr8ZZmZoQ3zhuGfMnSR/F2" crossorigin="anonymous"></script>
 		
-		<style>
-		
-			.main_logo { 
+	<style>	
+ 		.main_logo { 
 				display: block; 
 				margin-right: auto; 
 				margin-left: auto; 
 				width: 550px; 
 				height: 297px; 
 			}
+			
+			.nav-item {
+			 padding:3px;
+			}
+			
+			.nav-link {
+			 font-size:1.4em;
+			}
+			
 			.navbar-nav {
     			float:none;
    				margin: auto;
-    			/* vertical menu */
-    			/* display: block; */
     			text-align: center;
 			}
-			.navbar .active { background: #cacdd1; }
-                        .text { padding-top: 25px; }
 		</style>
 	</head>
 
@@ -38,15 +45,18 @@
 		
 		<div class="container">
 
-			<nav class="navbar navbar-toggleable-md navbar-light bg-faded">
+			<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
+		  <span class="navbar-toggler-icon"></span>
+		</button>
 
-  				<div class="collapse navbar-collapse" id="navbarSupportedContent">
-    				<ul class="navbar-nav mr-auto">
-      					<li class="nav-item">
+		<div class="collapse navbar-collapse" id="navbarColor01">
+		  <ul class="navbar-nav mr-auto">
+		  <li class="nav-item">
         					<a class="nav-link" href="index.html">Home 
         					<span class="sr-only">(current)</span></a>
       					</li>
-      					<li class="nav-item">
+      <li class="nav-item">
         					<a class="nav-link" href="submission_guidelines.html">Submission Guidelines</a>
       					</li>
 					<li class="nav-item">
@@ -67,29 +77,42 @@
 					<li class="nav-item">
         					<a class="nav-link" href="faq.html">FAQ</a>
       					</li>
-  				</div>
-			
-			</nav>
+     </ul>
+		</div>
+	</nav>
       
-      			<br/><h4>paleorXiv Diversity Statement</h4>
+   <h3 style="padding-top:1em;">paleorXiv Diversity Statement</h3>
                        
-<p style="text-align: justify;">Capturing a broad spectrum of interest and experiences will help paleorXiv consider and include the full Paleontology community. An essential step to achieving this objective is to ensure broad and intersectional diversity in staffing its Steering Committee.</p>
-<p style="text-align: justify;">Paleontology research is conducted by people of a diverse range of demographics and psychographics, including gender identities, sexual orientations, racial and cultural backgrounds, abilities, religions, ages, career stages and fields, and socioeconomic and immigration statuses. These intersectional identities impact on how research is conducted, data analyzed, and results shared. We recognize that a diverse and inclusive scientific community asks a broader range of questions yet also faces different barriers to participating in Paleontology. By listening to diverse voices, we will be rewarded by a greater understanding of our world.</p>
-<p style="text-align: justify;">In an effort to represent and include the broadest possible spectrum of geoscientists, paleoarXiv is committed to the following objectives in forming its Steering Committee:</p>
-	<ul>
-<li style="text-align: justify;"> <strong>FIELD:</strong> We will aim to include representatives from a broad spectrum of Paleontology fields such as invertebrate and vertebrate paleontology and paleobiology, paleoecology, paleobotany, paleohistology, paleogeography, paleoclimatology, paleobiogeography, and biostratigraphy.</li>
-<li style="text-align: justify;"> <strong>GENDER IDENTITY:</strong> We will strive for gender parity in our Steering Committee, with awareness of the need for flexibility to include transgender and gender-fluid people.</li>
-<li style="text-align: justify;"> <strong>ETHNIC AND CULTURAL BACKGROUND:</strong> We will strive to include a broad range of ethnic and cultural backgrounds in our Advisory Council, with particular focus on traditionally excluded populations including Asian, black, indigenous, Pacific island, and Latin scientists.</li>
-<li style="text-align: justify;"> <strong>GEOGRAPHY:</strong> We will respect the global nature of the geoscience community by aiming for an equal split of representatives from or working in Europe, North America, Asia, and the rest of the world.</li>
-<li style="text-align: justify;"> <strong>CAREER:</strong> We will aim to have at least one representative each from key stages within academia including students; early-, mid-, and late-career professors; researchers at teaching-centric and research-centric universities; and independent scholars.</li>
-<li style="text-align: justify;"> <strong>ABILITY:</strong> We will aim to include representatives with a broad range of physical and mental abilities.</li>
-<li style="text-align: justify;"> <strong>NEURODIVERSITY:</strong> We will aim to include viewpoints from neurodiverse individuals recognising their advantages and skills.</li>
-<li style="text-align: justify;"> <strong>SEXUAL ORIENTATION:</strong> We will aim to include representatives with a broad range of sexual orientations.</li>
-	</ul>
-<p style="text-align: justify;">It is our hope that meeting all these objectives within the current 7-person Steering Committee will subsequently include a range of intersectional identities to further enhance our understanding. We recognize that we may not always achieve all of these objectives, and will be as transparent as possible about our effectiveness within the confines of respecting the privacy of our Steering Committee members.</p>
-<p style="text-align: justify;">We also recognize we may not yet be considering all aspects of how identity shapes the science that we do. We further commit to continuing to learn and adapt how we define and include diverse populations in response to the needs of our greater community.</p>
-<p style="text-align: justify;">If you are interested in joining the Steering Committee, please contact us <a href="mailto:jon.tennant.2@gmail.com">here</a>.</p>
+	<p>Capturing a broad spectrum of interest and experiences will help paleorXiv consider and include the full Paleontology community. An essential step to achieving this objective is to ensure broad and intersectional diversity in staffing its Steering Committee.</p>
+	
+	<p>Paleontology research is conducted by people of a diverse range of demographics and psychographics, including gender identities, sexual orientations, racial and cultural backgrounds, abilities, religions, ages, career stages and fields, and socioeconomic and immigration statuses. These intersectional identities impact on how research is conducted, data analyzed, and results shared. We recognize that a diverse and inclusive scientific community asks a broader range of questions yet also faces different barriers to participating in Paleontology. By listening to diverse voices, we will be rewarded by a greater understanding of our world.</p>
+	
+	<p>In an effort to represent and include the broadest possible spectrum of geoscientists, paleoarXiv is committed to the following objectives in forming its Steering Committee:</p>
+		<ul>
+			<li> <strong>FIELD:</strong> We will aim to include representatives from a broad spectrum of Paleontology fields such as invertebrate and vertebrate paleontology and paleobiology, paleoecology, paleobotany, paleohistology, paleogeography, paleoclimatology, paleobiogeography, and biostratigraphy.</li>
+			<li> <strong>GENDER IDENTITY:</strong> We will strive for gender parity in our Steering Committee, with awareness of the need for flexibility to include transgender and gender-fluid people.</li>
+			<li> <strong>ETHNIC AND CULTURAL BACKGROUND:</strong> We will strive to include a broad range of ethnic and cultural backgrounds in our Advisory Council, with particular focus on traditionally excluded populations including Asian, black, indigenous, Pacific island, and Latin scientists.</li>
+			<li> <strong>GEOGRAPHY:</strong> We will respect the global nature of the geoscience community by aiming for an equal split of representatives from or working in Europe, North America, Asia, and the rest of the world.</li>
+			<li> <strong>CAREER:</strong> We will aim to have at least one representative each from key stages within academia including students; early-, mid-, and late-career professors; researchers at teaching-centric and research-centric universities; and independent scholars.</li>
+			<li> <strong>ABILITY:</strong> We will aim to include representatives with a broad range of physical and mental abilities.</li>
+			<li> <strong>NEURODIVERSITY:</strong> We will aim to include viewpoints from neurodiverse individuals recognising their advantages and skills.</li>
+			<li> <strong>SEXUAL ORIENTATION:</strong> We will aim to include representatives with a broad range of sexual orientations.</li>
+		</ul>
+		
+	<p>It is our hope that meeting all these objectives within the current 7-person Steering Committee will subsequently include a range of intersectional identities to further enhance our understanding. We recognize that we may not always achieve all of these objectives, and will be as transparent as possible about our effectiveness within the confines of respecting the privacy of our Steering Committee members.</p>
+	
+	<p>We also recognize we may not yet be considering all aspects of how identity shapes the science that we do. We further commit to continuing to learn and adapt how we define and include diverse populations in response to the needs of our greater community.</p>
+	
+	<p>If you are interested in joining the Steering Committee, please contact us <a href="mailto:jon.tennant.2@gmail.com">here</a>.</p>
 				
+		<footer id="footer">
+			<hr/>	
+			
+			<!-- add a license here -->
+			           
+      <p>Contact email: <a href="mailto:jon.tennant.2@gmail.com">jon dot tennant dot 2 at gmail dot com</a>. Source code can found at <a href="https://github.com/paleorXiv/paleorXiv.github.io">paleorXiv/paleorXiv.github.io</a>. Based on <a href="https://getbootstrap.com" rel="nofollow">Bootstrap</a>. Theme is <a href="https://bootswatch.com/yeti/">Yeti</a> from <a href="https://bootswatch.com/">Bootswatch</a>. Icons from <a href="http://fontawesome.io/" rel="nofollow">Font Awesome</a>.</p>
+    </footer>	
+    
 		</div>
 	</body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -6,30 +6,37 @@
 		<meta charset="utf-8">
 		<title>PaleorXiv</title>
 
-		<!-- Latest compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+		<!-- Latest compiled and minified CSS -- YETI from bootswatch theme -->
+		<link href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0-beta.3/yeti/bootstrap.min.css" rel="stylesheet" integrity="sha384-xpQNcoacYF/4TKVs2uD3sXyaQYs49wxwEmeFNkOUgun6SLWdEbaCOv8hGaB9jLxt" crossorigin="anonymous">
+		
+		<!-- Latest compiled and minified FontAwesome -->
+		<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
 		<!-- Latest compiled and minified JavaScript -->
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.bundle.min.js" integrity="sha384-VspmFJ2uqRrKr3en+IG0cIq1Cl/v/PHneDw6SQZYgrcr8ZZmZoQ3zhuGfMnSR/F2" crossorigin="anonymous"></script>
 		
-		<style>
-		
-			.main_logo { 
+	<style>	
+ 		.main_logo { 
 				display: block; 
 				margin-right: auto; 
 				margin-left: auto; 
 				width: 550px; 
 				height: 297px; 
 			}
+			
+			.nav-item {
+			 padding:3px;
+			}
+			
+			.nav-link {
+			 font-size:1.4em;
+			}
+			
 			.navbar-nav {
     			float:none;
    				margin: auto;
-    			/* vertical menu */
-    			/* display: block; */
     			text-align: center;
 			}
-			.navbar .active { background: #cacdd1; }
-                        .text { padding-top: 25px; }
 		</style>
 	</head>
 
@@ -38,15 +45,18 @@
 		
 		<div class="container">
 
-			<nav class="navbar navbar-toggleable-md navbar-light bg-faded">
+			<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
+		  <span class="navbar-toggler-icon"></span>
+		</button>
 
-  				<div class="collapse navbar-collapse" id="navbarSupportedContent">
-    				<ul class="navbar-nav mr-auto">
-      					<li class="nav-item">
+		<div class="collapse navbar-collapse" id="navbarColor01">
+		  <ul class="navbar-nav mr-auto">
+		  <li class="nav-item">
         					<a class="nav-link" href="index.html">Home 
         					<span class="sr-only">(current)</span></a>
       					</li>
-					<li class="nav-item">
+      <li class="nav-item active">
         					<a class="nav-link" href="submission_guidelines.html">Submission Guidelines</a>
       					</li>
 					<li class="nav-item">
@@ -64,60 +74,80 @@
 					<li class="nav-item">
         					<a class="nav-link" href="resources.html">Resources</a>
 					</li>
-					<li class="nav-item active">
+					<li class="nav-item">
         					<a class="nav-link" href="faq.html">FAQ</a>
       					</li>
-  				</div>
-			
-			</nav>
+     </ul>
+		</div>
+	</nav>
       
-       <h5><br/>Brand new to preprints? Check out this introductory video from ASAPBio</h5>
+       <h3 style="padding-top:1em; padding-bottom:0.5em;">Brand new to preprints? Check out this introductory video from ASAPBio</h3>
 			    <div class="video">
 				    <iframe width="560" height="315" src="https://www.youtube.com/embed/2zMgY8Dx9co" frameborder="0" allowfullscreen align:center text-align:center></iframe>
 			    </div>
           
-          	<strong>FAQ 1: Why publish a paper if the work is already published as a preprint?</strong>
-         	  <p>In the present reward system, journal publications influence funding and promotion decisions; the vast majority of research-paper preprints in physics are therefore <a href="http://asapbio.org/wp-content/uploads/2016/02/hhmi_feb16.pdf"> also submitted to journals</a>. Journals provide additional services including:</p>
-           	   	<li>Peer review</li>
-           	   	<li>Increased visibility</li>
-          	   	<li>Editorial control and standards</li>
-           	   	<li>Branding and marketing</li>
-             	<strong>FAQ 2: Will someone steal my work in my preprint?</strong>
-			<li>Based on experiences at very established (e.g., ArXiv) and newer, but rapidly growing preprint services (e.g. BiorXiv, SocArXiv), there is no clear evidence that preprints lead to being scooped.</li>
-			<li>If someone is prepared to steal ideas from a timestamped/’DOI’d’ preprint, they would likely do the same from material in a journal or from a conference presentation.</li>
-			<li>The reputational damage associated with intellectual theft and plagiarism is significant and long-lasting; thus the latter is very rare.</li>
-	    	<strong>FAQ 3: Will preprints lead to large volumes of  low-quality material on paleorXiv?</strong>
-			<li>Anecdotal evidence suggests this behaviour has not emerged in the communities that use the arXiv.</li>
-			<li>Because preprinting requires public disclosure, authors are wary of developing a bad reputation. If the work is poor, it will likely be ignored by the rest of the community. The same applies to material published in any journal.</li>
-			<li>RSS feeds allow sorting of material in paleorXiv; cf. Google Scholar.</li>
-			<li>Initial evidence and download statistics suggests paleorXiv is hosting high-quality, desirable material.</li>
-	   	<strong>FAQ 4: Can paleorXiv host only preprints?</strong>
-			<li>No. paleorXiv is also a repository for postprints (i.e. material already published in a journal).</li>
-			<li>Depending on journal policy, we can host the Author Accepted Manuscript (i.e. accepted version of paper, but before publisher typesetting) (AAMs) or the Version of Record (VoR) (i.e. published version of paper, after publisher typesetting).</li>
-			<li>Check your journal’s policy on self-archiving <a href="https://paleorxiv.github.io/journal_policies.html"> using paleorXiv's database</a></li>
-			<li>PaleorXiv can also host datasets, textbooks, book chapters, etc. Please contact us if you have any queries!</li>
-		<strong>FAQ 5: Will publishing a preprint mean I can’t publish in a journal?</strong>
-			<li>In most cases, the answer is ‘no’.</li>
-			<li>Use of preprints has been ongoing in other disciplines for, in some cases, a few decades, many publishers have preprint-friendly policies already in place for their journals.</li>
-			<li>Again, please check your journal’s policy on our database <a href="https://paleorxiv.github.io/journal_policies.html"> here</a> for more information.</li>
-			<li>Check before you submit - if you’re unsure, ask!</li>
-		<strong>FAQ 6: How do I link data to my preprint?</strong>
-			<li><a href="https://osf.io/">Open Science Framework’s</a> infrastructure allows for an unlimited amount of space for direct uploading of publication-related data, but limited to 5GB per file.</li>
-			<li>More commonly, data, and especially large volumes of data, are stored on external sites (e.g. Dropbox, GitHub, figshare, Google Drive) and linked back to the related preprint/postprint.</li>
-			<li>More information on connecting these services via the OSF can be found <a href="http://help.osf.io/m/addons/l/524148-connect-add-ons"> here</a>.</li>
-		<strong>FAQ 7: Does my preprint get a DOI and how might this impact citation count?</strong>	
-			<li>Preprints are minted with a DOI upon submission, which will persist even if the research is eventually published in a journal.</li>
-			<li>Preprints can collect citations, which count towards your h-Index.</li>
-			<li>Citations could, in theory, be split between preprints and the VoR.</li>
-			<li>The solution is to aggregate the citations through Google Scholar.</li>
-			<li>Preprints can direct readers to the published version (Version of Record or ‘VoR’) via a DOI; evidence indicates researchers typically cite the latter and not the former.</li>
-		<strong>FAQ 8: How do you pronounce paleorXiv?</strong>
-			<p>Short answer: "Paleo-archive". This pronounciation is to honour the arXiv ("archive"), the model of which paleorXiv is based on.</p>
-		<strong>FAQ 9: What can I post to paleorXiv?</strong>
-			<p>Although paleorXiv is part of the <a href="https://osf.io/preprints/"> Open Science Framework Preprints service</a>, we host academic research at a number of stages in the research process:</p>
-			<li>Working papers: Any draft of a paper that is ready to share with interested parties, but has not yet been peer reviewed. If you are sharing your work with a group of colleagues, a conference, or a journal, this may be the perfect time to widen the circle and post it on paleoXiv.</li>
-			<li>Preprints: Most people use this term to refer to completed papers that have not yet been peer reviewed (like working papers), and typically at some stage within the submission/publication process at a journal. However you define preprints, paleorXiv will host them.</li>
-			<li>Postprints: After a paper has been published by a journal (or accepted for publication), this is a version that you elect to share on our open platform. It may be a version that does not include the journal’s formatting or other changes, but has undergone peer review. This is the version you share when you’ve published something but it’s behind a paywall and you want anyone to be able to read it.</li>
-		</div>
+       <a href="#faq1"><h4 style="padding-top:1em;">FAQ 1</a>: Why publish a paper if the work is already published as a preprint?</h4>
+       <p style="padding-bottom:0em; margin-bottom:0em;">In the present reward system, journal publications influence funding and promotion decisions; the vast majority of research-paper preprints in physics are therefore <a href="http://asapbio.org/wp-content/uploads/2016/02/hhmi_feb16.pdf"> also submitted to journals</a>. Journals provide additional services including:</p>
+       	<ul style="padding-top:0em;">
+		     	<li>Peer review</li>
+		     	<li>Increased visibility</li>
+		     	<li>Editorial control and standards</li>
+		     	<li>Branding and marketing</li>
+       	</ul>
+      
+      <a href="#faq2"><h4 style="padding-top:0.5em;">FAQ 2</a>: Will someone steal my work in my preprint?</h4>
+			<ul>
+				<li>Based on experiences at very established (e.g., ArXiv) and newer, but rapidly growing preprint services (e.g. BiorXiv, SocArXiv), there is no clear evidence that preprints lead to being scooped.</li>
+				<li>If someone is prepared to steal ideas from a timestamped/’DOI’d’ preprint, they would likely do the same from material in a journal or from a conference presentation.</li>
+				<li>The reputational damage associated with intellectual theft and plagiarism is significant and long-lasting; thus the latter is very rare.</li>
+			</ul>
+	    
+	    <a href="#faq3"><h4 style="padding-top:0.5em;">FAQ 3</a>: Will preprints lead to large volumes of  low-quality material on paleorXiv?</h4>
+			<ul>
+				<li>Anecdotal evidence suggests this behaviour has not emerged in the communities that use the arXiv.</li>
+				<li>Because preprinting requires public disclosure, authors are wary of developing a bad reputation. If the work is poor, it will likely be ignored by the rest of the community. The same applies to material published in any journal.</li>
+				<li>RSS feeds allow sorting of material in paleorXiv; cf. Google Scholar.</li>
+				<li>Initial evidence and download statistics suggests paleorXiv is hosting high-quality, desirable material.</li>
+			</ul>
+	   	
+	   	<a href="#faq4"><h4 style="padding-top:0.5em;">FAQ 4</a>: Can paleorXiv host only preprints?</h4>
+			<ul>
+				<li>No. paleorXiv is also a repository for postprints (i.e. material already published in a journal).</li>
+				<li>Depending on journal policy, we can host the Author Accepted Manuscript (i.e. accepted version of paper, but before publisher typesetting) (AAMs) or the Version of Record (VoR) (i.e. published version of paper, after publisher typesetting).</li>
+				<li>Check your journal’s policy on self-archiving <a href="https://paleorxiv.github.io/journal_policies.html"> using paleorXiv's database</a></li>
+				<li>PaleorXiv can also host datasets, textbooks, book chapters, etc. Please contact us if you have any queries!</li>
+			</ul>
+		
+		  <a href="#faq5"><h4 style="padding-top:0.5em;">FAQ 5</a>: Will publishing a preprint mean I can’t publish in a journal?</h4>
+			<ul>
+				<li>In most cases, the answer is ‘no’.</li>
+				<li>Use of preprints has been ongoing in other disciplines for, in some cases, a few decades, many publishers have preprint-friendly policies already in place for their journals.</li>
+				<li>Again, please check your journal’s policy on our database <a href="https://paleorxiv.github.io/journal_policies.html"> here</a> for more information.</li>
+				<li>Check before you submit - if you’re unsure, ask!</li>
+			</ul>
+		
+		  <a href="#faq6"><h4 style="padding-top:0.5em;">FAQ 6</a>: How do I link data to my preprint?</h4>
+			<ul>
+				<li><a href="https://osf.io/">Open Science Framework’s</a> infrastructure allows for an unlimited amount of space for direct uploading of publication-related data, but limited to 5GB per file.</li>
+				<li>More commonly, data, and especially large volumes of data, are stored on external sites (e.g. Dropbox, GitHub, figshare, Google Drive) and linked back to the related preprint/postprint.</li>
+				<li>More information on connecting these services via the OSF can be found <a href="http://help.osf.io/m/addons/l/524148-connect-add-ons"> here</a>.</li>
+			</ul>
+		
+		  <a href="#faq7"><h4 style="padding-top:0.5em;">FAQ 7</a>: Does my preprint get a DOI and how might this impact citation count?</h4>	
+			<ul>
+				<li>Preprints are minted with a DOI upon submission, which will persist even if the research is eventually published in a journal.</li>
+				<li>Preprints can collect citations, which count towards your h-Index.</li>
+				<li>Citations could, in theory, be split between preprints and the VoR.</li>
+			</ul>
+			
+		<footer id="footer">
+			<hr/>	
+			
+			<!-- add a license here -->
+			           
+      <p>Contact email: <a href="mailto:jon.tennant.2@gmail.com">jon dot tennant dot 2 at gmail dot com</a>. Source code can found at <a href="https://github.com/paleorXiv/paleorXiv.github.io">paleorXiv/paleorXiv.github.io</a>. Based on <a href="https://getbootstrap.com" rel="nofollow">Bootstrap</a>. Theme is <a href="https://bootswatch.com/yeti/">Yeti</a> from <a href="https://bootswatch.com/">Bootswatch</a>. Icons from <a href="http://fontawesome.io/" rel="nofollow">Font Awesome</a>.</p>
+    </footer>	
+    
+    </div>
 	</body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,47 +7,57 @@
 		<meta charset="utf-8">
 		<title>PaleorXiv</title>
 
-		<!-- Latest compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+		<!-- Latest compiled and minified CSS -- YETI from bootswatch theme -->
+		<link href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0-beta.3/yeti/bootstrap.min.css" rel="stylesheet" integrity="sha384-xpQNcoacYF/4TKVs2uD3sXyaQYs49wxwEmeFNkOUgun6SLWdEbaCOv8hGaB9jLxt" crossorigin="anonymous">
+		
+		<!-- Latest compiled and minified FontAwesome -->
+		<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
 		<!-- Latest compiled and minified JavaScript -->
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.bundle.min.js" integrity="sha384-VspmFJ2uqRrKr3en+IG0cIq1Cl/v/PHneDw6SQZYgrcr8ZZmZoQ3zhuGfMnSR/F2" crossorigin="anonymous"></script>
 		
-		<style>
-		
-			.main_logo { 
+	<style>	
+ 		.main_logo { 
 				display: block; 
 				margin-right: auto; 
 				margin-left: auto; 
 				width: 550px; 
 				height: 297px; 
 			}
+			
+			.nav-item {
+			 padding:3px;
+			}
+			
+			.nav-link {
+			 font-size:1.4em;
+			}
+			
 			.navbar-nav {
     			float:none;
    				margin: auto;
-    			/* vertical menu */
-    			/* display: block; */
     			text-align: center;
 			}
-			.navbar .active { background: #cacdd1; }
-                        .text { padding-top: 25px; }
 		</style>
 	</head>
 
 	<body>
 		<img class="main_logo" src="paleorxiv_logo.png" alt="PaleorXiv logo"><br/>
 		
-		<div class="container">
+   <div class="container">
+		
+	 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
+		  <span class="navbar-toggler-icon"></span>
+		</button>
 
-			<nav class="navbar navbar-toggleable-md navbar-light bg-faded">
-
-  				<div class="collapse navbar-collapse" id="navbarSupportedContent">
-    				<ul class="navbar-nav mr-auto">
-      					<li class="nav-item active">
+		<div class="collapse navbar-collapse" id="navbarColor01">
+		  <ul class="navbar-nav mr-auto">
+		  <li class="nav-item active">
         					<a class="nav-link" href="index.html">Home 
         					<span class="sr-only">(current)</span></a>
       					</li>
-					<li class="nav-item">
+      <li class="nav-item">
         					<a class="nav-link" href="submission_guidelines.html">Submission Guidelines</a>
       					</li>
 					<li class="nav-item">
@@ -68,63 +78,74 @@
 					<li class="nav-item">
         					<a class="nav-link" href="faq.html">FAQ</a>
       					</li>
-  				</div>
+     </ul>
+		</div>
+	</nav>
 			
-			</nav>
-<h4 style="text-align: justify;">Welcome to paleorXiv!</h4>
-<p style="text-align: justify;"><a href="https://osf.io/preprints/paleorxiv/">PaleorXiv</a> is a free, open source and community-led digital archive for Paleontology research. We provide a non-profit platform for paleontologists to upload their working papers, pre-prints, accepted manuscripts (post-prints), and published papers. We also provide options to link data and code, and for article versioning. PaleorXiv is dedicated to speeding and opening up paleontological research and helping to build the future of scholarly communication.</p>
-<p style="text-align: justify;">We launched in the summer of 2017, and are <strong>open for <a href="https://osf.io/preprints/paleorxiv/submit">submissions</a></strong>.</p>
-&nbsp;
+		<h3 style="padding-top:1em;">Welcome to paleorXiv!</h3>
+		<p><a href="https://osf.io/preprints/paleorxiv/">PaleorXiv</a> is a free, open source and community-led digital archive for Paleontology research. We provide a non-profit platform for paleontologists to upload their working papers, pre-prints, accepted manuscripts (post-prints), and published papers. We also provide options to link data and code, and for article versioning. PaleorXiv is dedicated to speeding and opening up paleontological research and helping to build the future of scholarly communication.</p>
+		<p>We launched in the summer of 2017, and are <strong>open for <a href="https://osf.io/preprints/paleorxiv/submit">submissions</a></strong>.</p>
+		&nbsp;
 
-<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSZNWpJ8VNmk9HhDUOmm4X4UQhiO2NSw1ap6Ny0d1eeuNJDlycFKwnzhMeAD62dbAWQf6xUuknE4qv0/embed?start=true&amp;loop=true&amp;delayms=5000" width="960" height="569" frameborder="0" allowfullscreen="allowfullscreen"></iframe>
-<ul>
- 	<li style="text-align: justify;">Follow us on <a href="https://twitter.com/paleorxiv">Twitter</a>.</li>
- 	<li style="text-align: justify;">For submission inquiries, please <a href="mailto:jon.tennant.2@gmail.com" target="_blank" rel="noopener noreferrer">email us</a>, and see our <a href="https://paleorxiv.github.io/submission_guidelines.html" target="_blank" rel="noopener noreferrer">submission guidelines</a>.</li>
- 	<li style="text-align: justify;">A database of self-archiving ('Green Open Access') policies for journals that publish Paleontology research can be <a href="https://paleorxiv.github.io/journal_policies.html">found here</a>.</li>
- 	<li>Please also see our <a href="https://paleorxiv.github.io/diversity_statement.html" target="_blank" rel="noopener">Diversity Statement</a> and <a href="https://paleorxiv.github.io/code_of_conduct.html" target="_blank" rel="noopener">Code of Conduct</a>.</li>
- </ul>
+		<iframe src="https://docs.google.com/presentation/d/e/2PACX-1vSZNWpJ8VNmk9HhDUOmm4X4UQhiO2NSw1ap6Ny0d1eeuNJDlycFKwnzhMeAD62dbAWQf6xUuknE4qv0/embed?start=true&amp;loop=true&amp;delayms=5000" width="960" height="569" frameborder="0" allowfullscreen="allowfullscreen"></iframe>
+		
+		<ul style="padding-top:1em;">
+		 	<li>Follow us on <a href="https://twitter.com/paleorxiv">Twitter</a>.</li>
+		 	<li>For submission inquiries, please <a href="mailto:jon.tennant.2@gmail.com" target="_blank" rel="noopener noreferrer">email us</a>, and see our <a href="https://paleorxiv.github.io/submission_guidelines.html" target="_blank" rel="noopener noreferrer">submission guidelines</a>.</li>
+		 	<li>A database of self-archiving ('Green Open Access') policies for journals that publish Paleontology research can be <a href="https://paleorxiv.github.io/journal_policies.html">found here</a>.</li>
+		 	<li>Please also see our <a href="https://paleorxiv.github.io/diversity_statement.html" target="_blank" rel="noopener">Diversity Statement</a> and <a href="https://paleorxiv.github.io/code_of_conduct.html" target="_blank" rel="noopener">Code of Conduct</a>.</li>
+		 </ul>
 
-		<h4 style="text-align: justify;">PaleorXiv Steering Committee</h4>
-<p style="text-align: justify;">PaleorXiv is led by a Steering Committee comprised of members from the global Palaeontology community:</p>
+				<h4>PaleorXiv Steering Committee</h4>
+		<p>PaleorXiv is led by a Steering Committee comprised of members from the global Palaeontology community:</p>
 
-<ul style="text-align: justify;">
- 	<li><a href="https://twitter.com/Protohedgehog">Jon Tennant</a>, Open Science MOOC, founder of paleorXiv</li>
- 	<li><a href="https://twitter.com/josteist">Jostein Starrfelt</a>, University of Oslo, Norway</li>
- 	<li><a href="https://twitter.com/FossilTurtles">Jérémy Anquetin</a>, University of Fribourg and Jurassic Museum, Switzerland</li>
- 	<li><a href="https://twitter.com/danpeppe">Dan Peppe</a>, Baylor University, USA</li>
- 	<li><a href="https://twitter.com/taphovenatrix">Caitlin Syme</a>, University of Queensland, Australia</li>
- 	<li><a href="http://www.paleolab.com.br/">Gabriel Ferreira</a>, Universidade de São Paulo</li>
- 	<li><a href="https://twitter.com/tharkibo">Thea Boodhoo</a>, Institute for the Study of Mongolian Dinosaurs</li>
-</ul>
-<p style="text-align: justify;">Please <a href="mailto:jon.tennant.2@gmail.com" target="_blank" rel="noopener noreferrer">email us</a> if you would like to be involved.</p>
+		<ul>
+		 	<li><a href="https://twitter.com/Protohedgehog">Jon Tennant</a>, Open Science MOOC, founder of paleorXiv | <a href="https://twitter.com/Protohedgehog"><i class="fa fa-twitter"></i></a></li> 			 
+		 	<li><a href="https://starrfelt.wordpress.com">Jostein Starrfelt</a>, University of Oslo, Norway | <a href="https://twitter.com/josteist"><i class="fa fa-twitter"></i></a></li>
+		 	<li><a href="http://www.jurassica.ch/en/jeremyanquetin/">Jérémy Anquetin</a>, University of Fribourg and Jurassic Museum, Switzerland | <a href="https://twitter.com/FossilTurtles"><i class="fa fa-twitter"></i></a></li>
+		 	<li><a href="http://sites.baylor.edu/daniel_peppe/">Dan Peppe</a>, Baylor University, USA | <a href="https://twitter.com/danpeppe"><i class="fa fa-twitter"></i></a></li>
+		 	<li><a href="http://www.caitlinsyme.com">Caitlin Syme</a>, University of Queensland, Australia | <a href="https://twitter.com/taphovenatrix"><i class="fa fa-twitter"></i></a></li>
+		 	<li><a href="http://www.paleolab.com.br/">Gabriel Ferreira</a>, Universidade de São Paulo</li>
+		 	<li><a href="https://mongoliandinosaurs.org/author/tharkibogmail-com/">Thea Boodhoo</a>, Institute for the Study of Mongolian Dinosaurs | <a href="https://twitter.com/tharkibo"><i class="fa fa-twitter"></i></a></li>
+		</ul>
+		<p>Please <a href="mailto:jon.tennant.2@gmail.com" target="_blank" rel="noopener noreferrer">email us</a> if you would like to be involved.</p>
 
-<h4 style="text-align: justify;">Important links and media</h4>
-<ul style="text-align: justify;">
- 	<li><a href="http://help.osf.io/m/preprints/l/627729-share-a-preprint#Modify-permissions-and-citations">A guide to posting preprints</a> (Open Science Framework)</li>
- 	<li>PaleorXiv on <a href="https://en.wikipedia.org/wiki/Preprint">Wikipedia</a></li>
- 	<li>PaleorXiv in <a href="https://www.nature.com/news/heavyweight-funders-back-central-site-for-life-sciences-preprints-1.21466">Nature News</a></li>
- 	<li><a href="http://fossilsandshit.com/should-we-cite-preprints/" target="_blank" rel="noopener noreferrer">Discussion on citing preprints</a></li>
- 	<li><a href="http://lifesciencenetwork.com/blogs/leah-cannon/2017/05/30/changing-the-status-quo-jon-tennant-communications-director-at-scienceopen">Life Sciences Network</a> feature</li>
- 	<li>PaleorXiv in <a href="http://policynotes.arl.org/?p=1555">ARL Policy Notes</a></li>
- 	<li><a href="https://thebiologist.rsb.org.uk/biologist-opinion/159-biologist/opinion/1790-should-biologists-cite-preprints">Should we cite preprints?</a> (Royal Society of Biology editorial includes paleorXiv)</li>
- 	<li>Fossil News: <a href="https://fossilnews.org/whats-inside-fossil-news-summer-2017/">What would Open Access to all Paleontology research look like?</a></li>
- 	<li>Nature Index: <a href="https://www.natureindex.com/news-blog/encouraging-palaeontologists-to-stop-hiding-the-bones">Encouraging paleontologists to stop hiding the bones</a></li>
- 	<li>COS press release: <a href="https://cos.io/about/news/six-new-preprint-services-join-growing-community-across-disciplines-accelerate-scholarly-communication/">Six New Preprint Services Join a Growing Community Across Disciplines to Accelerate Scholarly Communication</a></li>
- 	<li>The Open Access interviews: <a href="http://poynder.blogspot.de/2017/08/the-open-access-interviews-rusty.html">Rusty Spiedel, the Center for Open Science</a></li>
- 	<li><a href="https://medium.com/flockademic/these-trailblazers-are-paving-the-way-for-open-access-7d098172112b">Flockademic</a>: These trailblazers are paving the way for Open Access</li>
- 	<li><a href="https://www.digital-science.com/blog/news/podcast-preprints-peer-review-publishing/">Digital Science podcast</a>: Preprints, peer review and publishing</li>
-</ul>
+		<h4>Important links and media</h4>
+		<ul>
+		 	<li><a href="http://help.osf.io/m/preprints/l/627729-share-a-preprint#Modify-permissions-and-citations">A guide to posting preprints</a> (Open Science Framework)</li>
+		 	<li>PaleorXiv on <a href="https://en.wikipedia.org/wiki/Preprint">Wikipedia</a></li>
+		 	<li>PaleorXiv in <a href="https://www.nature.com/news/heavyweight-funders-back-central-site-for-life-sciences-preprints-1.21466">Nature News</a></li>
+		 	<li><a href="http://fossilsandshit.com/should-we-cite-preprints/" target="_blank" rel="noopener noreferrer">Discussion on citing preprints</a></li>
+		 	<li><a href="http://lifesciencenetwork.com/blogs/leah-cannon/2017/05/30/changing-the-status-quo-jon-tennant-communications-director-at-scienceopen">Life Sciences Network</a> feature</li>
+		 	<li>PaleorXiv in <a href="http://policynotes.arl.org/?p=1555">ARL Policy Notes</a></li>
+		 	<li><a href="https://thebiologist.rsb.org.uk/biologist-opinion/159-biologist/opinion/1790-should-biologists-cite-preprints">Should we cite preprints?</a> (Royal Society of Biology editorial includes paleorXiv)</li>
+		 	<li>Fossil News: <a href="https://fossilnews.org/whats-inside-fossil-news-summer-2017/">What would Open Access to all Paleontology research look like?</a></li>
+		 	<li>Nature Index: <a href="https://www.natureindex.com/news-blog/encouraging-palaeontologists-to-stop-hiding-the-bones">Encouraging paleontologists to stop hiding the bones</a></li>
+		 	<li>COS press release: <a href="https://cos.io/about/news/six-new-preprint-services-join-growing-community-across-disciplines-accelerate-scholarly-communication/">Six New Preprint Services Join a Growing Community Across Disciplines to Accelerate Scholarly Communication</a></li>
+		 	<li>The Open Access interviews: <a href="http://poynder.blogspot.de/2017/08/the-open-access-interviews-rusty.html">Rusty Spiedel, the Center for Open Science</a></li>
+		 	<li><a href="https://medium.com/flockademic/these-trailblazers-are-paving-the-way-for-open-access-7d098172112b">Flockademic</a>: These trailblazers are paving the way for Open Access</li>
+		 	<li><a href="https://www.digital-science.com/blog/news/podcast-preprints-peer-review-publishing/">Digital Science podcast</a>: Preprints, peer review and publishing</li>
+		</ul>
 				
-<h4>On the blog</h4>
-<ul>
- 	<li><a href="http://fossilsandshit.com/paleorxiv-now-open-for-submissions/">PaleorXiv now open for submissions!</a></li>
- 	<li><a href="http://fossilsandshit.com/draft-submission-guidelines-paleorxiv/">Draft submission guidelines for paleorXiv</a></li>
- 	<li><a href="http://fossilsandshit.com/welcome-to-paleorxiv/" target="_blank" rel="noopener">Welcome to paleorXiv!</a></li>
- 	<li><a href="http://fossilsandshit.com/paleorxiv-press-release/" target="_blank" rel="noopener">PaleorXiv is a free publishing platform for Paleontology</a></li>
-</ul>
-<p style="text-align: justify;">Our technology partner is the <a href="https://cos.io/" target="_blank" rel="noopener noreferrer">Center for Open Science</a>, which hosts the PaleorXiv through the Open Science Framework <a href="https://osf.io/preprints/" target="_blank" rel="noopener noreferrer">Preprints server</a>.</p>
-<a class="twitter-timeline" href="https://twitter.com/paleorxiv">Tweets by paleorxiv</a> <script async src="//platform.twitter.com/widgets.js" charset="utf-8" data-width="300" data-limit="5"></script>
+		<h4>On the blog</h4>
+		<ul>
+		 	<li><a href="http://fossilsandshit.com/paleorxiv-now-open-for-submissions/">PaleorXiv now open for submissions!</a></li>
+		 	<li><a href="http://fossilsandshit.com/draft-submission-guidelines-paleorxiv/">Draft submission guidelines for paleorXiv</a></li>
+		 	<li><a href="http://fossilsandshit.com/welcome-to-paleorxiv/" target="_blank" rel="noopener">Welcome to paleorXiv!</a></li>
+		 	<li><a href="http://fossilsandshit.com/paleorxiv-press-release/" target="_blank" rel="noopener">PaleorXiv is a free publishing platform for Paleontology</a></li>
+		</ul>
+		
+		<p>Our technology partner is the <a href="https://cos.io/" target="_blank" rel="noopener noreferrer">Center for Open Science</a>, which hosts the PaleorXiv through the Open Science Framework <a href="https://osf.io/preprints/" target="_blank" rel="noopener noreferrer">Preprints server</a>.</p>
+		
+		<p><a class="twitter-timeline" href="https://twitter.com/paleorxiv">Tweets by paleorxiv</a> <script async src="//platform.twitter.com/widgets.js" charset="utf-8" data-width="300" data-limit="5"></script></p>
+		
+		<footer id="footer">
+			<hr/>	
 			
+			<!-- add a license here -->
+			           
+      <p>Contact email: <a href="mailto:jon.tennant.2@gmail.com">jon dot tennant dot 2 at gmail dot com</a>. Source code can found at <a href="https://github.com/paleorXiv/paleorXiv.github.io">paleorXiv/paleorXiv.github.io</a>. Based on <a href="https://getbootstrap.com" rel="nofollow">Bootstrap</a>. Theme is <a href="https://bootswatch.com/yeti/">Yeti</a> from <a href="https://bootswatch.com/">Bootswatch</a>. Icons from <a href="http://fontawesome.io/" rel="nofollow">Font Awesome</a>.</p>
+    </footer>			
 
 		</div>
 	</body>

--- a/journal_policies.html
+++ b/journal_policies.html
@@ -6,30 +6,37 @@
 		<meta charset="utf-8">
 		<title>PaleorXiv</title>
 
-		<!-- Latest compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+		<!-- Latest compiled and minified CSS -- YETI from bootswatch theme -->
+		<link href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0-beta.3/yeti/bootstrap.min.css" rel="stylesheet" integrity="sha384-xpQNcoacYF/4TKVs2uD3sXyaQYs49wxwEmeFNkOUgun6SLWdEbaCOv8hGaB9jLxt" crossorigin="anonymous">
+		
+		<!-- Latest compiled and minified FontAwesome -->
+		<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
 		<!-- Latest compiled and minified JavaScript -->
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.bundle.min.js" integrity="sha384-VspmFJ2uqRrKr3en+IG0cIq1Cl/v/PHneDw6SQZYgrcr8ZZmZoQ3zhuGfMnSR/F2" crossorigin="anonymous"></script>
 		
-		<style>
-		
-			.main_logo { 
+	<style>	
+ 		.main_logo { 
 				display: block; 
 				margin-right: auto; 
 				margin-left: auto; 
 				width: 550px; 
 				height: 297px; 
 			}
+			
+			.nav-item {
+			 padding:3px;
+			}
+			
+			.nav-link {
+			 font-size:1.4em;
+			}
+			
 			.navbar-nav {
     			float:none;
    				margin: auto;
-    			/* vertical menu */
-    			/* display: block; */
     			text-align: center;
 			}
-			.navbar .active { background: #cacdd1; }
-                        .text { padding-top: 25px; }
 		</style>
 	</head>
 
@@ -38,18 +45,21 @@
 		
 		<div class="container">
 
-			<nav class="navbar navbar-toggleable-md navbar-light bg-faded">
+			<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
+		  <span class="navbar-toggler-icon"></span>
+		</button>
 
-  				<div class="collapse navbar-collapse" id="navbarSupportedContent">
-    				<ul class="navbar-nav mr-auto">
-      					<li class="nav-item">
+		<div class="collapse navbar-collapse" id="navbarColor01">
+		  <ul class="navbar-nav mr-auto">
+		  <li class="nav-item">
         					<a class="nav-link" href="index.html">Home 
         					<span class="sr-only">(current)</span></a>
       					</li>
-      					<li class="nav-item">
+      <li class="nav-item">
         					<a class="nav-link" href="submission_guidelines.html">Submission Guidelines</a>
       					</li>
-					<li class="nav-item active">
+					<li class="nav-item  active">
         					<a class="nav-link" href="journal_policies.html">Journal Policies</a>
       					</li>
 					<li class="nav-item">
@@ -67,38 +77,48 @@
 					<li class="nav-item">
         					<a class="nav-link" href="faq.html">FAQ</a>
       					</li>
-  				</div>
-			
-			</nav>
+     </ul>
+		</div>
+	</nav>
            
 				
-		<h4 style="text-align: justify;">Paleontology journal policies</h4>
+		<h3 style="padding-top:1em;">Paleontology journal policies</h3>
 
-<a style="text-align: justify;" href="https://osf.io/preprints/paleorxiv/submit"><strong>paleorXiv is open for submissions!</strong></a>
+		<a href="https://osf.io/preprints/paleorxiv/submit"><strong>paleorXiv is open for submissions!</strong></a>
 				
-<p style="text-align: justify;">This is a list of pre-print, post-print, and VOR self-archiving policies for journals that publish peer reviewed Paleontology research. A full version of the database is maintained <strong><a href="https://docs.google.com/spreadsheets/d/13Sh3j2i7ZQokuofrqX89W149m1dyZZBl5GgUGd2-6ck/edit?usp=sharing">here</a></strong>. It is free for anyone to edit, and will automatically update the table below with changes. Please note that many journals do not have explicit self-archiving policies. Where this is the case, we are currently working with those journals to develop them.</p>
-<p style="text-align: justify;">Also included are data on whether or not a journal has a 'Gold Open Access' option (including 'hybrid' journals), and the APC for this (VAT excluded), should there be one.</p>
+		<p>This is a list of pre-print, post-print, and VOR self-archiving policies for journals that publish peer reviewed Paleontology research. A full version of the database is maintained <strong><a href="https://docs.google.com/spreadsheets/d/13Sh3j2i7ZQokuofrqX89W149m1dyZZBl5GgUGd2-6ck/edit?usp=sharing">here</a></strong>. It is free for anyone to edit, and will automatically update the table below with changes. Please note that many journals do not have explicit self-archiving policies. Where this is the case, we are currently working with those journals to develop them.</p>
+		
+		<p>Also included are data on whether or not a journal has a 'Gold Open Access' option (including 'hybrid' journals), and the APC for this (VAT excluded), should there be one.</p>
 
-<iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vRGuKCduW6I0wL3eI4YvOw-Yq173gX7Fy6ciLgVkaxV_lMts65R5S8ZolMkLkyolDl6w7KCc6bBfu1Z/pubhtml?widget=true&amp;headers=true" width="900" height="400" scrolling="yes"></iframe>
+		<iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vRGuKCduW6I0wL3eI4YvOw-Yq173gX7Fy6ciLgVkaxV_lMts65R5S8ZolMkLkyolDl6w7KCc6bBfu1Z/pubhtml?widget=true&amp;headers=true" width="900" height="400" scrolling="yes"></iframe>
 				
-	<h4 style="text-align: justify;">Additional information</h4>
-<ul>
- 	<li><strong><a href="https://en.wikipedia.org/wiki/Preprint">Preprint</a>: </strong>Version of a research paper prior to peer review.</li>
- 	<li><strong><a href="https://en.wikipedia.org/wiki/Postprint">Postprint</a>: </strong>Version of a research paper subsequent to peer review, but before any type-setting or copy-editing by the publisher.</li>
- 	<li><strong>VOR:</strong> Version of Record, the final, published record of a research paper.</li>
- 	<li><strong><a href="https://en.wikipedia.org/wiki/Open_access#Journals:_gold_open_access">Gold OA</a></strong>: Is the final VOR Open Access at the point of publication.</li>
- 	<li><strong><a href="https://en.wikipedia.org/wiki/Article_processing_charge">APC</a></strong>: Article-Processing Charge - the charge levied by some publishers to publish a paper as Open Access.</li>
- 	<li><strong><a href="https://en.wikipedia.org/wiki/Impact_factor">Impact Factor</a></strong>:  The yearly average number of <a title="Citation" href="https://en.wikipedia.org/wiki/Citation">citations</a> to recent articles published in that journal (note: <a href="http://biorxiv.org/content/early/2016/07/05/062109">this metric is a poor indicator of the quality of individual papers</a>).</li>
-</ul>
-<p style="text-align: justify;">The greatest effort has been exercised to maintain the accuracy of the information here. However, there might be errors as journal policies are updated through time. If there are data missing or incorrect in the table below, please feel free to edit them yourself. You can also <a href="mailto:jon.tennant.2@gmail.com" target="_blank" rel="noopener noreferrer">alert</a> us and we will update accordingly.</p>
+			<h4 style="padding-top:1em;">Additional information</h4>
+				<ul>
+				 	<li><strong><a href="https://en.wikipedia.org/wiki/Preprint">Preprint</a>: </strong>Version of a research paper prior to peer review.</li>
+				 	<li><strong><a href="https://en.wikipedia.org/wiki/Postprint">Postprint</a>: </strong>Version of a research paper subsequent to peer review, but before any type-setting or copy-editing by the publisher.</li>
+				 	<li><strong>VOR:</strong> Version of Record, the final, published record of a research paper.</li>
+				 	<li><strong><a href="https://en.wikipedia.org/wiki/Open_access#Journals:_gold_open_access">Gold OA</a></strong>: Is the final VOR Open Access at the point of publication.</li>
+				 	<li><strong><a href="https://en.wikipedia.org/wiki/Article_processing_charge">APC</a></strong>: Article-Processing Charge - the charge levied by some publishers to publish a paper as Open Access.</li>
+				 	<li><strong><a href="https://en.wikipedia.org/wiki/Impact_factor">Impact Factor</a></strong>:  The yearly average number of <a title="Citation" href="https://en.wikipedia.org/wiki/Citation">citations</a> to recent articles published in that journal (note: <a href="http://biorxiv.org/content/early/2016/07/05/062109">this metric is a poor indicator of the quality of individual papers</a>).</li>
+				</ul>
+				
+		<p>The greatest effort has been exercised to maintain the accuracy of the information here. However, there might be errors as journal policies are updated through time. If there are data missing or incorrect in the table below, please feel free to edit them yourself. You can also <a href="mailto:jon.tennant.2@gmail.com" target="_blank" rel="noopener noreferrer">alert</a> us and we will update accordingly.</p>
 
-	<h4 style="text-align: justify;">Additional resources</h4>
-<ul>
- 	<li><a href="https://www.americangeosciences.org/georef/open-access-journalsseries">GeoRef Open Access journals</a></li>
- 	<li><a href="http://paleopolis.rediris.es/geosciences/">Geoscience eJournals</a></li>
- 	<li><a href="https://figshare.com/articles/Elsevier_embargo_periods_2013_2015/1554748">Elsevier embargo period details</a></li>
- 	<li><a href="http://flourishoa.org/search">Flourish OA search engine</a></li>
-</ul>					
+	  <h4>Additional resources</h4>
+			<ul>
+			 	<li><a href="https://www.americangeosciences.org/georef/open-access-journalsseries">GeoRef Open Access journals</a></li>
+			 	<li><a href="http://paleopolis.rediris.es/geosciences/">Geoscience eJournals</a></li>
+			 	<li><a href="https://figshare.com/articles/Elsevier_embargo_periods_2013_2015/1554748">Elsevier embargo period details</a></li>
+			 	<li><a href="http://flourishoa.org/search">Flourish OA search engine</a></li>
+			</ul>					
+
+		<footer id="footer">
+			<hr/>	
+			
+			<!-- add a license here -->
+			           
+      <p>Contact email: <a href="mailto:jon.tennant.2@gmail.com">jon dot tennant dot 2 at gmail dot com</a>. Source code can found at <a href="https://github.com/paleorXiv/paleorXiv.github.io">paleorXiv/paleorXiv.github.io</a>. Based on <a href="https://getbootstrap.com" rel="nofollow">Bootstrap</a>. Theme is <a href="https://bootswatch.com/yeti/">Yeti</a> from <a href="https://bootswatch.com/">Bootswatch</a>. Icons from <a href="http://fontawesome.io/" rel="nofollow">Font Awesome</a>.</p>
+    </footer>	
 
 		</div>
 	</body>

--- a/moderation.html
+++ b/moderation.html
@@ -6,30 +6,37 @@
 		<meta charset="utf-8">
 		<title>PaleorXiv</title>
 
-		<!-- Latest compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+		<!-- Latest compiled and minified CSS -- YETI from bootswatch theme -->
+		<link href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0-beta.3/yeti/bootstrap.min.css" rel="stylesheet" integrity="sha384-xpQNcoacYF/4TKVs2uD3sXyaQYs49wxwEmeFNkOUgun6SLWdEbaCOv8hGaB9jLxt" crossorigin="anonymous">
+		
+		<!-- Latest compiled and minified FontAwesome -->
+		<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
 		<!-- Latest compiled and minified JavaScript -->
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.bundle.min.js" integrity="sha384-VspmFJ2uqRrKr3en+IG0cIq1Cl/v/PHneDw6SQZYgrcr8ZZmZoQ3zhuGfMnSR/F2" crossorigin="anonymous"></script>
 		
-		<style>
-		
-			.main_logo { 
+	<style>	
+ 		.main_logo { 
 				display: block; 
 				margin-right: auto; 
 				margin-left: auto; 
 				width: 550px; 
 				height: 297px; 
 			}
+			
+			.nav-item {
+			 padding:3px;
+			}
+			
+			.nav-link {
+			 font-size:1.4em;
+			}
+			
 			.navbar-nav {
     			float:none;
    				margin: auto;
-    			/* vertical menu */
-    			/* display: block; */
     			text-align: center;
 			}
-			.navbar .active { background: #cacdd1; }
-                        .text { padding-top: 25px; }
 		</style>
 	</head>
 
@@ -38,15 +45,18 @@
 		
 		<div class="container">
 
-			<nav class="navbar navbar-toggleable-md navbar-light bg-faded">
+			<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
+		  <span class="navbar-toggler-icon"></span>
+		</button>
 
-  				<div class="collapse navbar-collapse" id="navbarSupportedContent">
-    				<ul class="navbar-nav mr-auto">
-      					<li class="nav-item">
+		<div class="collapse navbar-collapse" id="navbarColor01">
+		  <ul class="navbar-nav mr-auto">
+		  <li class="nav-item">
         					<a class="nav-link" href="index.html">Home 
         					<span class="sr-only">(current)</span></a>
       					</li>
-      					<li class="nav-item">
+      <li class="nav-item">
         					<a class="nav-link" href="submission_guidelines.html">Submission Guidelines</a>
       					</li>
 					<li class="nav-item">
@@ -67,34 +77,41 @@
 					<li class="nav-item">
         					<a class="nav-link" href="faq.html">FAQ</a>
       					</li>
-  				</div>
-			
-			</nav>
+     </ul>
+		</div>
+	</nav>
                        
-<h4 style="text-align: justify;">Purpose of paleorXiv moderation</h4>
-<p style="text-align: justify;"><span style="font-weight: 400;">PaleorXiv accepts scholarly work from across the field of Paleontology and Paleobiology, broadly defined, that is plausibly categorized and for which authors are correctly identified, and which authors have the legal right to share. We do not assess the quality or perceived merit of the work. The appearance of work is an invitation to the public and scholarly community to share, review, discuss, and evaluate it (and its linked or associated research materials); acceptance is not a statement about research quality. PaleorXiv thus empowers individuals, communities, and institutions to develop their own criteria, announcements, journals, lists, and analyses of scholarly work.</span></p>
-<h4 style="text-align: justify;">Policy</h4>
-<p style="text-align: justify;"><span style="font-weight: 400;">PaleorXiv accepts papers at any stage of the publication process. We moderate papers before they appear publicly, which is called “pre-moderation” on the Open Science Framework platform. To learn more about how this moderation works on our system, </span><a href="http://help.osf.io/m/preprints/l/806116-submitting-to-a-preprint-service-that-uses-moderation#submitting-to-preprint-service-that-uses-a-pre-moderation"><span style="font-weight: 400;">visit this page from our hosts</span></a><span style="font-weight: 400;">. Subject to volume demands, we expect to post papers submitted for moderation within 1-3 business days.</span></p>
-<p style="text-align: justify;"><span style="font-weight: 400;">The paleorXiv moderation process accepts papers that:</span></p>
+		<h3 style="padding-top:1em;">Purpose of paleorXiv moderation</h3>
+		<p><span style="font-weight: 400;">PaleorXiv accepts scholarly work from across the field of Paleontology and Paleobiology, broadly defined, that is plausibly categorized and for which authors are correctly identified, and which authors have the legal right to share. We do not assess the quality or perceived merit of the work. The appearance of work is an invitation to the public and scholarly community to share, review, discuss, and evaluate it (and its linked or associated research materials); acceptance is not a statement about research quality. PaleorXiv thus empowers individuals, communities, and institutions to develop their own criteria, announcements, journals, lists, and analyses of scholarly work.</span></p>
+		
+		<h4 style="text-align: justify;">Policy</h4>
+			<p><span style="font-weight: 400;">PaleorXiv accepts papers at any stage of the publication process. We moderate papers before they appear publicly, which is called “pre-moderation” on the Open Science Framework platform. To learn more about how this moderation works on our system, </span><a href="http://help.osf.io/m/preprints/l/806116-submitting-to-a-preprint-service-that-uses-moderation#submitting-to-preprint-service-that-uses-a-pre-moderation"><span style="font-weight: 400;">visit this page from our hosts</span></a><span style="font-weight: 400;">. Subject to volume demands, we expect to post papers submitted for moderation within 1-3 business days.</span></p>
+			<p><span style="font-weight: 400;">The paleorXiv moderation process accepts papers that:</span></p>
 
-<ol style="text-align: justify;">
- 	<li><span style="font-weight: 400;">Are scholarly content</span><span style="font-weight: 400;">. This includes original research, reviews, essays, critiques and comments on other work, systematic reviews, hypotheses, ‘negative’ results, and data and methods papers. Work on paleorXiv is either research or engages with research.</span></li>
- 	<li><span style="font-weight: 400;">Are in a research area that we support</span><span style="font-weight: 400;">. We accept work from across all domains of Paleontology and Paleobiology, including, but not limited to: Vertebrate paleontology; Invertebrate paleontology; Micropaleontology; Paleobotany; Paleoecology; Paleoclimatology; Paleogeography;  Paleoceanography; Paleohistology; Paleobiogegraphy; and Biostratigraphy..</span></li>
- 	<li><span style="font-weight: 400;">Are plausibly categorized</span><span style="font-weight: 400;">. We allow authors to select their own categories from our subject taxonomy, but check whether there are obvious errors or categorizations that lack plausibility.</span></li>
- 	<li><span style="font-weight: 400;">Are correctly attributed</span><span style="font-weight: 400;">. We do a simple Internet search to see if someone else has publicly claimed authorship of the work.</span></li>
- 	<li><span style="font-weight: 400;">Are in languages that we can moderate</span><span style="font-weight: 400;">. We welcome work submitted in any language, provided we have a moderator that can review it adequately according to our policy. Papers submitted in non-English languages will be held in the moderation queue until we can get them verified.</span></li>
-</ol>
-<p style="text-align: justify;"><span style="font-weight: 400;">For more information, please see our </span><a href="http://fossilsandshit.com/paleorxiv/submission-guidelines-authors/"><span style="font-weight: 400;">Submission Guidelines</span></a><span style="font-weight: 400;">, and check for compliance with our database of </span><a href="http://fossilsandshit.com/paleorxiv/journal-policies/"><span style="font-weight: 400;">Journal Policies</span></a><span style="font-weight: 400;"> before submitting.</span></p>
+			<ol>
+			 	<li><span style="font-weight: 400;">Are scholarly content</span><span style="font-weight: 400;">. This includes original research, reviews, essays, critiques and comments on other work, systematic reviews, hypotheses, ‘negative’ results, and data and methods papers. Work on paleorXiv is either research or engages with research.</span></li>
+			 	<li><span style="font-weight: 400;">Are in a research area that we support</span><span style="font-weight: 400;">. We accept work from across all domains of Paleontology and Paleobiology, including, but not limited to: Vertebrate paleontology; Invertebrate paleontology; Micropaleontology; Paleobotany; Paleoecology; Paleoclimatology; Paleogeography;  Paleoceanography; Paleohistology; Paleobiogegraphy; and Biostratigraphy..</span></li>
+			 	<li><span style="font-weight: 400;">Are plausibly categorized</span><span style="font-weight: 400;">. We allow authors to select their own categories from our subject taxonomy, but check whether there are obvious errors or categorizations that lack plausibility.</span></li>
+			 	<li><span style="font-weight: 400;">Are correctly attributed</span><span style="font-weight: 400;">. We do a simple Internet search to see if someone else has publicly claimed authorship of the work.</span></li>
+			 	<li><span style="font-weight: 400;">Are in languages that we can moderate</span><span style="font-weight: 400;">. We welcome work submitted in any language, provided we have a moderator that can review it adequately according to our policy. Papers submitted in non-English languages will be held in the moderation queue until we can get them verified.</span></li>
+			</ol>
+			<p><span style="font-weight: 400;">For more information, please see our </span><a href="http://fossilsandshit.com/paleorxiv/submission-guidelines-authors/"><span style="font-weight: 400;">Submission Guidelines</span></a><span style="font-weight: 400;">, and check for compliance with our database of </span><a href="http://fossilsandshit.com/paleorxiv/journal-policies/"><span style="font-weight: 400;">Journal Policies</span></a><span style="font-weight: 400;"> before submitting.</span></p>
 
-<h4 style="text-align: justify;">Copyright compliance</h4>
-<p style="text-align: justify;"><span style="font-weight: 400;">Moderation does include verification of copyright status, which we assess based on individual journal policies. Where we are uncertain, we check with submitting authors to verify their status. We seek to accept only papers that comply with copyright law. We ask that authors share only that work they have the right to share. Actively affirming this is part of the submission process for each paper uploaded. Please </span><a href="mailto:jon.tennant.2@gmail.com"><span style="font-weight: 400;">contact us</span></a><span style="font-weight: 400;"> if you are uncertain about this part of the procedure.</span></p>
-<p style="text-align: justify;"><span style="font-weight: 400;">Claims of copyright infringement should be sent to the Center for Open Science in accordance with their policy, which is </span><a href="https://github.com/CenterForOpenScience/cos.io/blob/master/TERMS_OF_USE.md"><span style="font-weight: 400;">here</span></a><span style="font-weight: 400;">.</span></p>
+		<h4>Copyright compliance</h4>
+		<p><span style="font-weight: 400;">Moderation does include verification of copyright status, which we assess based on individual journal policies. Where we are uncertain, we check with submitting authors to verify their status. We seek to accept only papers that comply with copyright law. We ask that authors share only that work they have the right to share. Actively affirming this is part of the submission process for each paper uploaded. Please </span><a href="mailto:jon.tennant.2@gmail.com"><span style="font-weight: 400;">contact us</span></a><span style="font-weight: 400;"> if you are uncertain about this part of the procedure.</span></p>
+		<p><span style="font-weight: 400;">Claims of copyright infringement should be sent to the Center for Open Science in accordance with their policy, which is </span><a href="https://github.com/CenterForOpenScience/cos.io/blob/master/TERMS_OF_USE.md"><span style="font-weight: 400;">here</span></a><span style="font-weight: 400;">.</span></p>
 
-<h4 style="text-align: justify;">Procedure</h4>
-<p style="text-align: justify;"><span style="font-weight: 400;">Work will be reviewed by a moderator before appearing publicly on paleorXiv. If a paper is not accepted, the moderator will include a description of the reason. Work that does not pass moderation will remain on the OSF platform but will not be identified as part of paleorXiv. Authors are free to resubmit such work after addressing the issues raised by the moderator. Authors also may </span><a href="mailto:jon.tennant.2@gmail.com"><span style="font-weight: 400;">contact us</span></a><span style="font-weight: 400;"> to discuss or appeal a moderation decision.</span></p>
-<p style="text-align: justify;"><span style="font-weight: 400;">Please note: At present we do not have the capacity to query authors during the moderation process. If a paper does not pass moderation we will specify reasons, but we can’t discuss the reasons with the author prior to making a decision. Please don’t be discouraged by negative moderation decisions, and feel free to contact us with any questions.</span></p>
+		<h4>Procedure</h4>
+		<p><span style="font-weight: 400;">Work will be reviewed by a moderator before appearing publicly on paleorXiv. If a paper is not accepted, the moderator will include a description of the reason. Work that does not pass moderation will remain on the OSF platform but will not be identified as part of paleorXiv. Authors are free to resubmit such work after addressing the issues raised by the moderator. Authors also may </span><a href="mailto:jon.tennant.2@gmail.com"><span style="font-weight: 400;">contact us</span></a><span style="font-weight: 400;"> to discuss or appeal a moderation decision.</span></p>
+		<p><span style="font-weight: 400;">Please note: At present we do not have the capacity to query authors during the moderation process. If a paper does not pass moderation we will specify reasons, but we can’t discuss the reasons with the author prior to making a decision. Please don’t be discouraged by negative moderation decisions, and feel free to contact us with any questions.</span></p>
 
-					
+		<footer id="footer">
+			<hr/>	
+			
+			<!-- add a license here -->
+			           
+      <p>Contact email: <a href="mailto:jon.tennant.2@gmail.com">jon dot tennant dot 2 at gmail dot com</a>. Source code can found at <a href="https://github.com/paleorXiv/paleorXiv.github.io">paleorXiv/paleorXiv.github.io</a>. Based on <a href="https://getbootstrap.com" rel="nofollow">Bootstrap</a>. Theme is <a href="https://bootswatch.com/yeti/">Yeti</a> from <a href="https://bootswatch.com/">Bootswatch</a>. Icons from <a href="http://fontawesome.io/" rel="nofollow">Font Awesome</a>.</p>
+    </footer>	
 
 		</div>
 	</body>

--- a/resources.html
+++ b/resources.html
@@ -1,4 +1,4 @@
-!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 
 	<head>
@@ -6,30 +6,37 @@
 		<meta charset="utf-8">
 		<title>PaleorXiv</title>
 
-		<!-- Latest compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+		<!-- Latest compiled and minified CSS -- YETI from bootswatch theme -->
+		<link href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0-beta.3/yeti/bootstrap.min.css" rel="stylesheet" integrity="sha384-xpQNcoacYF/4TKVs2uD3sXyaQYs49wxwEmeFNkOUgun6SLWdEbaCOv8hGaB9jLxt" crossorigin="anonymous">
+		
+		<!-- Latest compiled and minified FontAwesome -->
+		<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
 		<!-- Latest compiled and minified JavaScript -->
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.bundle.min.js" integrity="sha384-VspmFJ2uqRrKr3en+IG0cIq1Cl/v/PHneDw6SQZYgrcr8ZZmZoQ3zhuGfMnSR/F2" crossorigin="anonymous"></script>
 		
-		<style>
-		
-			.main_logo { 
+	<style>	
+ 		.main_logo { 
 				display: block; 
 				margin-right: auto; 
 				margin-left: auto; 
 				width: 550px; 
 				height: 297px; 
 			}
+			
+			.nav-item {
+			 padding:3px;
+			}
+			
+			.nav-link {
+			 font-size:1.4em;
+			}
+			
 			.navbar-nav {
     			float:none;
    				margin: auto;
-    			/* vertical menu */
-    			/* display: block; */
     			text-align: center;
 			}
-			.navbar .active { background: #cacdd1; }
-                        .text { padding-top: 25px; }
 		</style>
 	</head>
 
@@ -38,15 +45,18 @@
 		
 		<div class="container">
 
-			<nav class="navbar navbar-toggleable-md navbar-light bg-faded">
+			 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
+		  <span class="navbar-toggler-icon"></span>
+		</button>
 
-  				<div class="collapse navbar-collapse" id="navbarSupportedContent">
-    				<ul class="navbar-nav mr-auto">
-      					<li class="nav-item">
+		<div class="collapse navbar-collapse" id="navbarColor01">
+		  <ul class="navbar-nav mr-auto">
+		  <li>
         					<a class="nav-link" href="index.html">Home 
         					<span class="sr-only">(current)</span></a>
       					</li>
-					<li class="nav-item">
+      <li class="nav-item">
         					<a class="nav-link" href="submission_guidelines.html">Submission Guidelines</a>
       					</li>
 					<li class="nav-item">
@@ -67,10 +77,20 @@
 					<li class="nav-item">
         					<a class="nav-link" href="faq.html">FAQ</a>
       					</li>
-  				</div>
+     </ul>
+		</div>
+	</nav>
+	
+	<h2 style="padding-top:1em;">THIS PAGE IS UNDER CONSTRUCTION</h2>
+	
+		<footer id="footer">
+			<hr/>	
 			
-			</nav>
-THIS PAGE IS UNDER CONSTRUCTION
+			<!-- add a license here -->
+			           
+      <p>Contact email: <a href="mailto:jon.tennant.2@gmail.com">jon dot tennant dot 2 at gmail dot com</a>. Source code can found at <a href="https://github.com/paleorXiv/paleorXiv.github.io">paleorXiv/paleorXiv.github.io</a>. Based on <a href="https://getbootstrap.com" rel="nofollow">Bootstrap</a>. Theme is <a href="https://bootswatch.com/yeti/">Yeti</a> from <a href="https://bootswatch.com/">Bootswatch</a>. Icons from <a href="http://fontawesome.io/" rel="nofollow">Font Awesome</a>.</p>
+    </footer>	
+	
 		</div>
 	</body>
 </html>

--- a/submission_guidelines.html
+++ b/submission_guidelines.html
@@ -6,30 +6,37 @@
 		<meta charset="utf-8">
 		<title>PaleorXiv</title>
 
-		<!-- Latest compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
+		<!-- Latest compiled and minified CSS -- YETI from bootswatch theme -->
+		<link href="https://maxcdn.bootstrapcdn.com/bootswatch/4.0.0-beta.3/yeti/bootstrap.min.css" rel="stylesheet" integrity="sha384-xpQNcoacYF/4TKVs2uD3sXyaQYs49wxwEmeFNkOUgun6SLWdEbaCOv8hGaB9jLxt" crossorigin="anonymous">
+		
+		<!-- Latest compiled and minified FontAwesome -->
+		<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
 
 		<!-- Latest compiled and minified JavaScript -->
-		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.bundle.min.js" integrity="sha384-VspmFJ2uqRrKr3en+IG0cIq1Cl/v/PHneDw6SQZYgrcr8ZZmZoQ3zhuGfMnSR/F2" crossorigin="anonymous"></script>
 		
-		<style>
-		
-			.main_logo { 
+	<style>	
+ 		.main_logo { 
 				display: block; 
 				margin-right: auto; 
 				margin-left: auto; 
 				width: 550px; 
 				height: 297px; 
 			}
+			
+			.nav-item {
+			 padding:3px;
+			}
+			
+			.nav-link {
+			 font-size:1.4em;
+			}
+			
 			.navbar-nav {
     			float:none;
    				margin: auto;
-    			/* vertical menu */
-    			/* display: block; */
     			text-align: center;
 			}
-			.navbar .active { background: #cacdd1; }
-                        .text { padding-top: 25px; }
 		</style>
 	</head>
 
@@ -38,15 +45,18 @@
 		
 		<div class="container">
 
-			<nav class="navbar navbar-toggleable-md navbar-light bg-faded">
+		<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarColor01" aria-controls="navbarColor01" aria-expanded="false" aria-label="Toggle navigation">
+		  <span class="navbar-toggler-icon"></span>
+		</button>
 
-  				<div class="collapse navbar-collapse" id="navbarSupportedContent">
-    				<ul class="navbar-nav mr-auto">
-      					<li class="nav-item">
+		<div class="collapse navbar-collapse" id="navbarColor01">
+		  <ul class="navbar-nav mr-auto">
+		  <li class="nav-item">
         					<a class="nav-link" href="index.html">Home 
         					<span class="sr-only">(current)</span></a>
       					</li>
-      					<li class="nav-item active">
+      <li class="nav-item active">
         					<a class="nav-link" href="submission_guidelines.html">Submission Guidelines</a>
       					</li>
 					<li class="nav-item">
@@ -67,58 +77,63 @@
 					<li class="nav-item">
         					<a class="nav-link" href="faq.html">FAQ</a>
       					</li>
-  				</div>
-			
-			</nav>
+     </ul>
+		</div>
+	</nav>
 
-		<h4 style="text-align: justify;">Submission guidelines</h4>
+		<h3 style="padding-top:1em;">Submission guidelines</h3>
 				
-<p style="text-align: justify;"><a href="https://osf.io/preprints/paleorxiv/submit"><strong>PaleorXiv is open for submissions!</strong></a></p>
-<p style="text-align: justify;"><em>Please note that these guidelines are subject to change.</em>
+<p><a href="https://osf.io/preprints/paleorxiv/submit"><strong>PaleorXiv is open for submissions!</strong></a></p>
+<p><em>Please note that these guidelines are subject to change.</em>
 	
 	
-<h4 style="text-align: justify;">General information</h4>
-
-<ul style="text-align: justify;">
- 	<li style="text-align: justify;">PaleorXiv accepts all types of manuscript, including but not limited to systematic reviews, hypotheses, ‘negative’ results, and data and methods papers.</li>
- 	<li style="text-align: justify;">We publish two major types of article:
-	<ol>
-		<li style="text-align: justify;">Preprints of articles in parallel to traditional journal submissions.</li>
- 		<li style="text-align: justify;">Previously published articles that you wish to make Open Access.</li>
-	</ol>
- 	<li style="text-align: justify;">Please check the <strong><a href="https://paleorxiv.github.io/journal_policies.html/" target="_blank" rel="noopener">Journal Policies</a></strong> page for further details on self-archiving options.</li>
- 	<li style="text-align: justify;">We encourage submissions from all domains of Paleontology and Paleobiology, including, but not limited to: Vertebrate paleontology; Invertebrate paleontology; Micropaleontology; Paleobotany; Paleoecology; Paleoclimatology; Paleogeography;  Paleoceanography; Paleohistology; Paleobiogegraphy; and Biostratigraphy.</li>
- 	<li style="text-align: justify;">We do not accept letters or blog posts, or those which do not pass the normal community standards for submission.</li>
- 	<li style="text-align: justify;">Note that preprint publication does not replace publishing with journals, and we recommend authors to use the <a href="http://www.sherpa.ac.uk/romeo/index.php">SHERPA/RoMEO</a> service to check journal preprint policies. A Paleontology-specific and revised version of this database is maintained <strong><a href="http://fossilsandshit.com/paleorxiv/journal-policies/" target="_blank" rel="noopener">here</a></strong>.</li>
-</ul>
+		<h4>General information</h4>
+			<ul>
+			 	<li>PaleorXiv accepts all types of manuscript, including but not limited to systematic reviews, hypotheses, ‘negative’ results, and data and methods papers.</li>
+			 	<li>We publish two major types of article:
+				<ol>
+					<li>Preprints of articles in parallel to traditional journal submissions.</li>
+			 		<li>Previously published articles that you wish to make Open Access.</li>
+				</ol>
+			 	<li>Please check the <strong><a href="https://paleorxiv.github.io/journal_policies.html/" target="_blank" rel="noopener">Journal Policies</a></strong> page for further details on self-archiving options.</li>
+			 	<li>We encourage submissions from all domains of Paleontology and Paleobiology, including, but not limited to: Vertebrate paleontology; Invertebrate paleontology; Micropaleontology; Paleobotany; Paleoecology; Paleoclimatology; Paleogeography;  Paleoceanography; Paleohistology; Paleobiogegraphy; and Biostratigraphy.</li>
+			 	<li>We do not accept letters or blog posts, or those which do not pass the normal community standards for submission.</li>
+			 	<li>Note that preprint publication does not replace publishing with journals, and we recommend authors to use the <a href="http://www.sherpa.ac.uk/romeo/index.php">SHERPA/RoMEO</a> service to check journal preprint policies. A Paleontology-specific and revised version of this database is maintained <strong><a href="http://fossilsandshit.com/paleorxiv/journal-policies/" target="_blank" rel="noopener">here</a></strong>.</li>
+			</ul>
 				
-<h4 style="text-align: justify;">Your submissions</strong></h4>
-
-<ul style="text-align: justify;">
- 	<li style="text-align: justify;">All submissions will go through a basic moderation process to check for conformation with these guidelines.</li>
-	<li style="text-align: justify;">All published articles will be granted a CC BY 4.0 license and a DOI. All articles are indexed in Google Scholar.</li>
- 	<li style="text-align: justify;">Submissions that do not meet these guidelines will not be published, and the authors notified.</li>
- 	<li style="text-align: justify;">As common courtesy, please make sure that all co-authors are aware of, and have agreed to, submission. They will be notified upon submission of preprints.</li>
- 	<li style="text-align: justify;">Before submitting, it is recommended to add a note to the front page stating “This is a preprint that has been submitted to journal XXX” where applicable. When updating to the postprint or accepted author manuscript, please change to “This is a postprint that has been peer reviewed and accepted at journal XXX.” A template for this is available <strong><a href="https://github.com/paleorXiv/resources/blob/master/Cover%20letter%20template.pdf" rel="attachment wp-att-2620">here</a></strong>.</li>
- 	<li style="text-align: justify;">All preprints can be updated with the postprint version or author-accepted manuscript. Please check for journal compliance and embargo periods where needed.</li>
-</ul>
+		<h4>Your submissions</strong></h4>
+			<ul>
+			 	<li>All submissions will go through a basic moderation process to check for conformation with these guidelines.</li>
+				<li>All published articles will be granted a CC BY 4.0 license and a DOI. All articles are indexed in Google Scholar.</li>
+			 	<li>Submissions that do not meet these guidelines will not be published, and the authors notified.</li>
+			 	<li>As common courtesy, please make sure that all co-authors are aware of, and have agreed to, submission. They will be notified upon submission of preprints.</li>
+			 	<li>Before submitting, it is recommended to add a note to the front page stating “This is a preprint that has been submitted to journal XXX” where applicable. When updating to the postprint or accepted author manuscript, please change to “This is a postprint that has been peer reviewed and accepted at journal XXX.” A template for this is available <strong><a href="https://github.com/paleorXiv/resources/blob/master/Cover%20letter%20template.pdf" rel="attachment wp-att-2620">here</a></strong>.</li>
+			 	<li>All preprints can be updated with the postprint version or author-accepted manuscript. Please check for journal compliance and embargo periods where needed.</li>
+			</ul>
 			
-<h4 style="text-align: justify;">Using paleorXiv articles</h4>
-
-<ul style="text-align: justify;">
- 	<li>Please note that preprints are not formally peer reviewed. When re-using them, and especially when citing, this status should be clearly marked.</li>
- 	<li style="text-align: justify;">Please exercise the same care and judgment you would use for any research output when it comes to the re-use of preprints.</li>
- 	<li style="text-align: justify;">We strongly encourage community interaction through commenting and sharing of preprints.</li>
-</ul>
-<h4 style="text-align: justify;">Taxonomic submissions</h4>
-
-<ul style="text-align: justify;">
- 	<li style="text-align: justify;">When submitting taxonomic papers that identify new genera or species, please omit the name and replace with 'gen et. sp. nov.', as appropriate.</li>
- 	<li style="text-align: justify;">For newly named higher level taxa, recombinations, referrals, synonymisations, and phylogenetic definitions, we strongly advise that these be fully redacted too prior to submission.</li>
- 	<li style="text-align: justify;">For manuscripts that include a lot of taxonomic and systematic work, authors are advised to carefully consider the taxonomic implications before publishing.</li>
-</ul>
+			<h4>Using paleorXiv articles</h4>
+			<ul>
+			 	<li>Please note that preprints are not formally peer reviewed. When re-using them, and especially when citing, this status should be clearly marked.</li>
+			 	<li>Please exercise the same care and judgment you would use for any research output when it comes to the re-use of preprints.</li>
+			 	<li>We strongly encourage community interaction through commenting and sharing of preprints.</li>
+			</ul>
 			
-<p style="text-align: justify;">For more information, please contact us <a href="mailto:jon.tennant.2@gmail.com">here</a>.</p>
+			<h4>Taxonomic submissions</h4>
+			<ul>
+			 	<li>When submitting taxonomic papers that identify new genera or species, please omit the name and replace with 'gen et. sp. nov.', as appropriate.</li>
+			 	<li>For newly named higher level taxa, recombinations, referrals, synonymisations, and phylogenetic definitions, we strongly advise that these be fully redacted too prior to submission.</li>
+			 	<li>For manuscripts that include a lot of taxonomic and systematic work, authors are advised to carefully consider the taxonomic implications before publishing.</li>
+			</ul>
+			
+<p>For more information, please contact us <a href="mailto:jon.tennant.2@gmail.com">here</a>.</p>
+
+		<footer id="footer">
+			<hr/>	
+			
+			<!-- add a license here -->
+			
+			<p>Contact email: <a href="mailto:jon.tennant.2@gmail.com">jon dot tennant dot 2 at gmail dot com</a>. Source code can found at <a href="https://github.com/paleorXiv/paleorXiv.github.io">paleorXiv/paleorXiv.github.io</a>. Based on <a href="https://getbootstrap.com" rel="nofollow">Bootstrap</a>. Theme is <a href="https://bootswatch.com/yeti/">Yeti</a> from <a href="https://bootswatch.com/">Bootswatch</a>. Icons from <a href="http://fontawesome.io/" rel="nofollow">Font Awesome</a>.</p>
+    </footer>	
 
 		</div>
 	</body>


### PR DESCRIPTION
Hi Jon! You can view my alteration of the paleorXiv site live here: https://vickysteeves.github.io/paleorXiv.github.io/.

The biggest two changes I added to the site are:
1. Changed the theme from generic bootstrap to the [Yeti](https://bootswatch.com/yeti/) theme from [Bootswatch](https://bootswatch.com). I grabbed the relevant CDN link from the bootswatch maxCDN (where it seems you got everything else for the CSS and JavaScript)
2. I changed the version of Bootstrap you are using from the latest alpha release to the previous release, 4.0.0-beta.3. This works nicer with themes in general -- alpha means untested so...

I also got rid of all the "style: text-align;justify;" - this doesn't actually do much. And I added anchors to each of the FAQs so you can link to one individually. 

At the bottom of each page, I've added a footer (`<footer id="footer">`) with some basic information -- what the code is based off, where the source lives, and a contact email. I left a comment there for you to add a license as you want -- look for `<!-- add a license here -->` at the bottom of each `*.html`.

I hope this helps -- happy to work on it some more or explain anything else!