### PR TITLE
Fix broken links in index.html

### DIFF
--- a/code_of_conduct.html
+++ b/code_of_conduct.html
@@ -79,7 +79,7 @@
 		</div>
 	</nav>
 				
-	<h3 style="padding-top:1em;">paleorXiv Code of Conduct</h3>
+	<a id="codeofconduct"><h3 style="padding-top:1em;">paleorXiv Code of Conduct</h3></a>
                        
 	<p>In the interest of fostering an open and welcoming environment, we as contributors and maintainers of paleorXiv pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.</p>
 
@@ -116,7 +116,7 @@
 		<h4>Attribution</h4>
 			<p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org/">Contributor Covenant</a>, version 1.4, available at <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct.html">https://www.contributor-covenant.org/version/1/4/code-of-conduct.html</a></p>	
 
-	<h3 style="padding-top:1em;">paleorXiv Diversity Statement</h3>
+	<a id="diversitystatement"><h3 style="padding-top:1em;">paleorXiv Diversity Statement</h3></a>
                        
 	<p>Capturing a broad spectrum of interest and experiences will help paleorXiv consider and include the full Paleontology community. An essential step to achieving this objective is to ensure broad and intersectional diversity in staffing its Steering Committee.</p>
 	

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
 		<ul style="padding-top:1em;">
 		 	<li>Follow us on <a href="https://twitter.com/paleorxiv">Twitter</a>.</li>
 		 	<li>A database of self-archiving ('Green Open Access') policies for journals that publish Paleontology research can be <a href="https://paleorxiv.github.io/journal_policies.html">found here</a>.</li>
-		 	<li>Please also see our <a href="https://paleorxiv.github.io/code_of_conduct.html#diversitystatement" target="_blank" rel="noopener">Diversity Statement</a> and <a href="https://paleorxiv.github.io/code_of_conduct.html#codeofconduct" target="_blank" rel="noopener">Code of Conduct</a>.</li>
+		 	<li>Please also see our <a href="code_of_conduct.html#diversitystatement" target="_blank" rel="noopener">Diversity Statement</a> and <a href="code_of_conduct.html#codeofconduct" target="_blank" rel="noopener">Code of Conduct</a>.</li>
 		 </ul>
 
 		<h4>Important links and media</h4>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
 		<ul style="padding-top:1em;">
 		 	<li>Follow us on <a href="https://twitter.com/paleorxiv">Twitter</a>.</li>
 		 	<li>A database of self-archiving ('Green Open Access') policies for journals that publish Paleontology research can be <a href="https://paleorxiv.github.io/journal_policies.html">found here</a>.</li>
-		 	<li>Please also see our <a href="code_of_conduct.html#diversitystatement" target="_blank" rel="noopener">Diversity Statement</a> and <a href="code_of_conduct.html#codeofconduct" target="_blank" rel="noopener">Code of Conduct</a>.</li>
+		 	<li>Please also see our <a href="code_of_conduct.html#diversitystatement" target="_blank" rel="noopener">Diversity Statement</a> and <a href="code_of_conduct.html" target="_blank" rel="noopener">Code of Conduct</a>.</li>
 		 </ul>
 
 		<h4>Important links and media</h4>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
 		<ul style="padding-top:1em;">
 		 	<li>Follow us on <a href="https://twitter.com/paleorxiv">Twitter</a>.</li>
 		 	<li>A database of self-archiving ('Green Open Access') policies for journals that publish Paleontology research can be <a href="https://paleorxiv.github.io/journal_policies.html">found here</a>.</li>
-		 	<li>Please also see our <a href="https://paleorxiv.github.io/diversity_statement.html" target="_blank" rel="noopener">Diversity Statement</a> and <a href="https://paleorxiv.github.io/code_of_conduct.html" target="_blank" rel="noopener">Code of Conduct</a>.</li>
+		 	<li>Please also see our <a href="https://paleorxiv.github.io/code_of_conduct.html#diversitystatement" target="_blank" rel="noopener">Diversity Statement</a> and <a href="https://paleorxiv.github.io/code_of_conduct.html#codeofconduct" target="_blank" rel="noopener">Code of Conduct</a>.</li>
 		 </ul>
 
 		<h4>Important links and media</h4>


### PR DESCRIPTION
Our recent redesign broke two links on the home page: the diversity statement and code of conduct links on the home page at the moment cause 404 errors (not the navigation bar ones those are working fine, the 
broken ones are in the text). 

I fixed those links and also included internal pointers so the diversity statement link properly finds the diversity statement segment within the merged page.